### PR TITLE
Allow the injection of custom http clients

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,9 +3,10 @@ package fastshot
 import (
 	"errors"
 	"fmt"
-	"github.com/opus-domini/fast-shot/constant"
 	"net/http"
 	"net/url"
+
+	"github.com/opus-domini/fast-shot/constant"
 )
 
 // ClientBuilder serves as the main entry point for configuring HTTP clients.
@@ -28,7 +29,7 @@ func NewClient(baseURL string) *ClientBuilder {
 
 	return &ClientBuilder{
 		client: &ClientConfigBase{
-			httpClient:  &http.Client{},
+			httpClient:  NewHTTPClient(&http.Client{}),
 			httpHeader:  &http.Header{},
 			httpCookies: []*http.Cookie{},
 			validations: validations,
@@ -63,7 +64,7 @@ func NewClientLoadBalancer(baseURLs []string) *ClientBuilder {
 
 	return &ClientBuilder{
 		client: &ClientConfigBase{
-			httpClient:  &http.Client{},
+			httpClient:  NewHTTPClient(&http.Client{}),
 			httpHeader:  &http.Header{},
 			httpCookies: []*http.Cookie{},
 			validations: validations,

--- a/client_builder_config.go
+++ b/client_builder_config.go
@@ -2,10 +2,11 @@ package fastshot
 
 import (
 	"errors"
-	"github.com/opus-domini/fast-shot/constant"
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/opus-domini/fast-shot/constant"
 )
 
 // BuilderHttpClientConfig is the interface that wraps the basic methods for setting HTTP ClientConfig configuration.
@@ -23,22 +24,24 @@ func (b *ClientBuilder) Config() *ClientConfigBuilder {
 
 // SetCustomTransport sets custom transport for the HTTP client.
 func (b *ClientConfigBuilder) SetCustomTransport(transport http.RoundTripper) *ClientBuilder {
-	b.parentBuilder.client.HttpClient().Transport = transport
+	b.parentBuilder.client.HttpClient().SetTransport(transport)
 	return b.parentBuilder
 }
 
 // SetTimeout sets the timeout for the HTTP client.
 func (b *ClientConfigBuilder) SetTimeout(duration time.Duration) *ClientBuilder {
-	b.parentBuilder.client.HttpClient().Timeout = duration
+	b.parentBuilder.client.HttpClient().SetTimeout(duration)
 	return b.parentBuilder
 }
 
 // SetFollowRedirects controls whether the HTTP client should follow redirects.
 func (b *ClientConfigBuilder) SetFollowRedirects(follow bool) *ClientBuilder {
 	if !follow {
-		b.parentBuilder.client.HttpClient().CheckRedirect = func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		}
+		b.parentBuilder.client.HttpClient().SetCheckRedirect(
+			func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		)
 	}
 	return b.parentBuilder
 }
@@ -51,12 +54,12 @@ func (b *ClientConfigBuilder) SetProxy(proxyURL string) *ClientBuilder {
 		return b.parentBuilder
 	}
 
-	if transport, ok := b.parentBuilder.client.HttpClient().Transport.(*http.Transport); ok {
+	if transport, ok := b.parentBuilder.client.HttpClient().Transport().(*http.Transport); ok {
 		transport.Proxy = http.ProxyURL(parsedURL)
 	} else {
-		b.parentBuilder.client.HttpClient().Transport = &http.Transport{
+		b.parentBuilder.client.HttpClient().SetTransport(&http.Transport{
 			Proxy: http.ProxyURL(parsedURL),
-		}
+		})
 	}
 
 	return b.parentBuilder

--- a/client_builder_config.go
+++ b/client_builder_config.go
@@ -64,3 +64,9 @@ func (b *ClientConfigBuilder) SetProxy(proxyURL string) *ClientBuilder {
 
 	return b.parentBuilder
 }
+
+// SetRawClient sets the underlying raw client
+func (b *ClientConfigBuilder) SetRawClient(client RawClient) *ClientBuilder {
+	b.parentBuilder.client.SetHttpClient(client)
+	return b.parentBuilder
+}

--- a/client_builder_config_test.go
+++ b/client_builder_config_test.go
@@ -14,7 +14,7 @@ func TestClientConfigBuilder_SetTimeout(t *testing.T) {
 	// Act
 	builder.Config().SetTimeout(1)
 	// Assert
-	if builder.client.HttpClient().Timeout != 1 {
+	if builder.client.HttpClient().Timeout() != 1 {
 		t.Errorf("Timeout not set correctly")
 	}
 }
@@ -77,7 +77,7 @@ func TestClientConfigBuilder_SetCustomTransport(t *testing.T) {
 	// Act
 	builder.Config().SetCustomTransport(&http.Transport{})
 	// Assert
-	if builder.client.HttpClient().Transport == nil {
+	if builder.client.HttpClient().Transport() == nil {
 		t.Errorf("Transport not set correctly")
 	}
 }
@@ -88,7 +88,7 @@ func TestClientConfigBuilder_SetProxy(t *testing.T) {
 	// Act
 	builder.Config().SetProxy("http://localhost:8080")
 	// Assert
-	if builder.client.HttpClient().Transport == nil {
+	if builder.client.HttpClient().Transport() == nil {
 		t.Errorf("Transport not set correctly")
 	}
 }
@@ -106,7 +106,7 @@ func TestClientConfigBuilder_SetProxy_WithCustomTransport(t *testing.T) {
 		}).
 		Config().SetProxy("http://localhost:8080")
 	// Assert
-	if builder.client.HttpClient().Transport == nil {
+	if builder.client.HttpClient().Transport() == nil {
 		t.Errorf("Transport not set correctly")
 	}
 }
@@ -117,7 +117,7 @@ func TestClientConfigBuilder_SetProxy_WithProxyURLParserError(t *testing.T) {
 	// Act
 	builder.Config().SetProxy(":%^:")
 	// Assert
-	if builder.client.HttpClient().Transport != nil {
+	if builder.client.HttpClient().Transport() != nil {
 		t.Errorf("Transport should not be set")
 	}
 	if len(builder.client.Validations()) != 1 {

--- a/client_config_base.go
+++ b/client_config_base.go
@@ -1,16 +1,17 @@
 package fastshot
 
 import (
-	"github.com/opus-domini/fast-shot/constant/method"
 	"net/http"
 	"net/url"
 	"sync/atomic"
+
+	"github.com/opus-domini/fast-shot/constant/method"
 )
 
 type (
 	// ClientConfigBase serves as the main entry point for configuring HTTP clients.
 	ClientConfigBase struct {
-		httpClient  *http.Client
+		httpClient  RawClient
 		httpHeader  *http.Header
 		httpCookies []*http.Cookie
 		validations []error
@@ -43,7 +44,7 @@ func (c *BalancedBaseURL) BaseURL() *url.URL {
 }
 
 // HttpClient for ClientConfigBase returns the HTTP client.
-func (c *ClientConfigBase) HttpClient() *http.Client {
+func (c *ClientConfigBase) HttpClient() RawClient {
 	return c.httpClient
 }
 

--- a/client_config_base.go
+++ b/client_config_base.go
@@ -48,6 +48,11 @@ func (c *ClientConfigBase) HttpClient() RawClient {
 	return c.httpClient
 }
 
+// SetHttpClient for ClientConfigBase sets the RawClient.
+func (c *ClientConfigBase) SetHttpClient(client RawClient) {
+	c.httpClient = client
+}
+
 // HttpHeader for ClientConfigBase returns the HTTP header.
 func (c *ClientConfigBase) HttpHeader() *http.Header {
 	return c.httpHeader

--- a/interfaces.go
+++ b/interfaces.go
@@ -25,6 +25,7 @@ type Client interface {
 
 type ClientConfig interface {
 	HttpClient() RawClient
+	SetHttpClient(client RawClient)
 	HttpHeader() *http.Header
 	SetHttpCookie(cookie *http.Cookie)
 	HttpCookies() []*http.Cookie

--- a/interfaces.go
+++ b/interfaces.go
@@ -8,13 +8,23 @@ import (
 	"time"
 )
 
+// RawClient defines an interface for low level HTTP clients
+type RawClient interface {
+	Do(*http.Request) (*http.Response, error)
+	SetTransport(http.RoundTripper)
+	Transport() http.RoundTripper
+	SetTimeout(time.Duration)
+	Timeout() time.Duration
+	SetCheckRedirect(func(*http.Request, []*http.Request) error)
+}
+
 type Client interface {
 	ClientConfig
 	ClientHttpMethods
 }
 
 type ClientConfig interface {
-	HttpClient() *http.Client
+	HttpClient() RawClient
 	HttpHeader() *http.Header
 	SetHttpCookie(cookie *http.Cookie)
 	HttpCookies() []*http.Cookie

--- a/raw_client.go
+++ b/raw_client.go
@@ -1,0 +1,48 @@
+package fastshot
+
+import (
+	"net/http"
+	"time"
+)
+
+// HTTPClient decorates an *http.Client types to provide a RawClient interface
+type HTTPClient struct {
+	client *http.Client
+}
+
+var _ RawClient = &HTTPClient{}
+
+// Do will execute the *http.Client Do method
+func (c *HTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return c.client.Do(req)
+}
+
+// SetTransport sets the Transport field on the underlying http.Client type
+func (c *HTTPClient) SetTransport(transport http.RoundTripper) {
+	c.client.Transport = transport
+}
+
+// Transport will return the underlying transport type
+func (c *HTTPClient) Transport() http.RoundTripper {
+	return c.client.Transport
+}
+
+// SetTimeout sets the Timeout field on the underlying http.Client type
+func (c *HTTPClient) SetTimeout(duration time.Duration) {
+	c.client.Timeout = duration
+}
+
+// Timeout will return the underlying timeout value
+func (c *HTTPClient) Timeout() time.Duration {
+	return c.client.Timeout
+}
+
+// SetCheckRedirect sets the CheckRedirect field on the underlying http.Client type
+func (c *HTTPClient) SetCheckRedirect(f func(*http.Request, []*http.Request) error) {
+	c.client.CheckRedirect = f
+}
+
+// NewHTTPClient will create a wrapped *http.Client that confirms to the RawClient interface
+func NewHTTPClient(client *http.Client) *HTTPClient {
+	return &HTTPClient{client: client}
+}


### PR DESCRIPTION
## What 
This allows users to inject custom HTTP clients for user with the fast-shot client builder
## Why
Two primary use cases (a) Being able to use mocked clients for testing, and (b) Use of decorated, or instrumented clients. 