### PR TITLE
Fix retry when request has body

### DIFF
--- a/constant/constant.go
+++ b/constant/constant.go
@@ -9,4 +9,5 @@ const (
 	ErrMsgParseQueryString  = "failed to parse query string"
 	ErrMsgParseURL          = "failed to parse URL"
 	ErrMsgParseProxyURL     = "failed to parse proxy URL"
+	ErrMsgReadBody          = "failed to read body"
 )

--- a/request.go
+++ b/request.go
@@ -112,18 +112,13 @@ func (b *RequestBuilder) execute(req *http.Request) (Response, error) {
 	return Response{Request: b.request, RawResponse: response}, err
 }
 
-func (b *RequestBuilder) executeWithRetry() (Response, error) {
+func (b *RequestBuilder) executeWithRetry(req *http.Request) (Response, error) {
 	var config = b.request.config.RetryConfig()
 	var errExecution error
 	var errAttempts []error
 	var response Response
 
 	for attempt := uint(0); attempt < config.MaxAttempts(); attempt++ {
-		// For each unique attempt, create a new request instance to avoid side effects from previous attempts (e.g. request body)
-		req, err := b.createHTTPRequest()
-		if err != nil {
-			return Response{}, errors.Join(errors.New(constant.ErrMsgCreateRequest), err)
-		}
 		// Execute request
 		response, errExecution = b.execute(req)
 		// Check for errors
@@ -174,15 +169,15 @@ func (b *RequestBuilder) Send() (Response, error) {
 		return Response{}, errors.Join(errors.New(constant.ErrMsgRequestValidation), err)
 	}
 
-	// Check if maxAttempts are enabled
-	if b.request.config.RetryConfig() != nil && b.request.config.RetryConfig().MaxAttempts() > 1 {
-		return b.executeWithRetry()
-	}
-
 	// Create request
 	req, err := b.createHTTPRequest()
 	if err != nil {
 		return Response{}, errors.Join(errors.New(constant.ErrMsgCreateRequest), err)
+	}
+
+	// Check if maxAttempts are enabled
+	if b.request.config.RetryConfig() != nil && b.request.config.RetryConfig().MaxAttempts() > 1 {
+		return b.executeWithRetry(req)
 	}
 
 	// Execute the request

--- a/request_builder_body.go
+++ b/request_builder_body.go
@@ -27,8 +27,14 @@ func (b *RequestBuilder) Body() *RequestBodyBuilder {
 
 // AsReader sets the body as IO Reader.
 func (b *RequestBodyBuilder) AsReader(body io.Reader) *RequestBuilder {
-	b.requestConfig.SetBody(body)
-	return b.parentBuilder
+    buf := new(bytes.Buffer)
+    _, err := buf.ReadFrom(body)
+    if err != nil {
+        b.requestConfig.Validations().Add(errors.Join(errors.New(constant.ErrMsgReadBody), err))
+        return b.parentBuilder
+    }
+    b.requestConfig.SetBody(buf)
+    return b.parentBuilder
 }
 
 // AsString sets the body as string.

--- a/request_builder_body_test.go
+++ b/request_builder_body_test.go
@@ -2,9 +2,10 @@ package fastshot
 
 import (
 	"bytes"
-	"github.com/opus-domini/fast-shot/constant"
 	"strings"
 	"testing"
+
+	"github.com/opus-domini/fast-shot/constant"
 )
 
 func TestRequestBodyBuilder_AsReader(t *testing.T) {

--- a/request_builder_retry_test.go
+++ b/request_builder_retry_test.go
@@ -1,6 +1,7 @@
 package fastshot
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,12 +15,13 @@ func logServerResponse(responseStatus string) {
 	fmt.Printf("timestamp: %s, response: %s\n", time.Now().Format(time.StampMilli), responseStatus)
 }
 
+type retryConfig struct {
+	retryBuilder func(requestBuilder *RequestBuilder) *RequestBuilder
+	maxAttempts  uint
+	interval     time.Duration
+}
+
 func TestRequest_Send_Retry(t *testing.T) {
-	type retryConfig struct {
-		retryBuilder func(requestBuilder *RequestBuilder) *RequestBuilder
-		maxAttempts  uint
-		interval     time.Duration
-	}
 
 	tests := []struct {
 		name        string
@@ -27,7 +29,7 @@ func TestRequest_Send_Retry(t *testing.T) {
 		serverFunc  func() (http.HandlerFunc, *int)
 		expectError bool
 		expectCount int
-		withBody    bool
+		hasBody     bool
 	}{
 		{
 			name: "Retry Constant Backoff Successful",
@@ -55,34 +57,6 @@ func TestRequest_Send_Retry(t *testing.T) {
 			},
 			expectError: false,
 			expectCount: 3,
-		},
-		{
-			name: "Retry Constant Backoff With Body Successful",
-			retryConfig: retryConfig{
-				retryBuilder: func(requestBuilder *RequestBuilder) *RequestBuilder {
-					return requestBuilder.
-						Retry().SetConstantBackoff(time.Millisecond, 3)
-				},
-				interval:    time.Millisecond,
-				maxAttempts: 3,
-			},
-			serverFunc: func() (http.HandlerFunc, *int) {
-				retryCount := 0
-				return func(w http.ResponseWriter, r *http.Request) {
-					retryCount++
-					if retryCount < 3 {
-						logServerResponse("500 SERVER ERROR")
-						w.WriteHeader(http.StatusInternalServerError)
-						return
-					}
-					logServerResponse("200 OK")
-					w.WriteHeader(http.StatusOK)
-					_ = json.NewEncoder(w).Encode(map[string]string{"message": "Success!"})
-				}, &retryCount
-			},
-			expectError: false,
-			expectCount: 3,
-			withBody:    true,
 		},
 		{
 			name: "Retry Constant Backoff Unsuccessful",
@@ -258,6 +232,82 @@ func TestRequest_Send_Retry(t *testing.T) {
 			expectError: false,
 			expectCount: 5,
 		},
+		{
+			name: "Retry With Body Unsuccessful",
+			retryConfig: retryConfig{
+				retryBuilder: func(requestBuilder *RequestBuilder) *RequestBuilder {
+					return requestBuilder.
+						Retry().SetConstantBackoff(time.Millisecond, 3)
+				},
+				interval:    time.Millisecond,
+				maxAttempts: 3,
+			},
+			serverFunc: func() (http.HandlerFunc, *int) {
+				retryCount := 0
+				return func(w http.ResponseWriter, r *http.Request) {
+					retryCount++
+					bodyBytes, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Errorf("Error reading body: %v", err)
+					}
+					expectedBodyLength := len([]byte("wrong test body"))
+					if retryCount < 3 {
+						logServerResponse("500 SERVER ERROR")
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+					if len(bodyBytes) == expectedBodyLength {
+						logServerResponse("200 OK")
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(map[string]string{"message": "Success!"})
+						return
+					}
+					logServerResponse("500 SERVER ERROR")
+					w.WriteHeader(http.StatusInternalServerError)
+				}, &retryCount
+			},
+			expectError: true,
+			expectCount: 3,
+			hasBody:     true,
+		},
+		{
+			name: "Retry With Body Successful",
+			retryConfig: retryConfig{
+				retryBuilder: func(requestBuilder *RequestBuilder) *RequestBuilder {
+					return requestBuilder.
+						Retry().SetConstantBackoff(time.Millisecond, 3)
+				},
+				interval:    time.Millisecond,
+				maxAttempts: 3,
+			},
+			serverFunc: func() (http.HandlerFunc, *int) {
+				retryCount := 0
+				return func(w http.ResponseWriter, r *http.Request) {
+					retryCount++
+					bodyBytes, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Errorf("Error reading body: %v", err)
+					}
+					expectedBodyLength := len([]byte("test body"))
+					if retryCount < 3 {
+						logServerResponse("500 SERVER ERROR")
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+					if len(bodyBytes) == expectedBodyLength {
+						logServerResponse("200 OK")
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(map[string]string{"message": "Success!"})
+						return
+					}
+					logServerResponse("500 SERVER ERROR")
+					w.WriteHeader(http.StatusInternalServerError)
+				}, &retryCount
+			},
+			expectError: false,
+			expectCount: 3,
+			hasBody:     true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -268,15 +318,11 @@ func TestRequest_Send_Retry(t *testing.T) {
 			defer server.Close()
 
 			requestBuilder := DefaultClient(server.URL).GET("/test")
-			testBody := map[string]string{"key": "value"}
-			// Act
-			var resp Response
-			var err error
-			if !tt.withBody {
-				resp, err = tt.retryConfig.retryBuilder(requestBuilder).Send()
-			} else {
-				resp, err = tt.retryConfig.retryBuilder(requestBuilder).Body().AsJSON(testBody).Send()
+			if tt.hasBody {
+				requestBuilder.Body().AsReader(io.NopCloser(bytes.NewBufferString("test body")))
 			}
+			// Act
+			resp, err := tt.retryConfig.retryBuilder(requestBuilder).Send()
 
 			// Assert
 			if *retryCount != tt.expectCount {

--- a/request_builder_retry_test.go
+++ b/request_builder_retry_test.go
@@ -142,7 +142,6 @@ func TestRequest_Send_Retry(t *testing.T) {
 					retryCount++
 					logServerResponse("500 SERVER ERROR")
 					w.WriteHeader(http.StatusInternalServerError)
-					return
 				}, &retryCount
 			},
 			expectError: true,

--- a/request_config_base.go
+++ b/request_config_base.go
@@ -1,6 +1,7 @@
 package fastshot
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net/url"
@@ -89,7 +90,13 @@ func (c *RequestConfigBase) Validations() ValidationsWrapper {
 
 // SetBody sets the body for the request.
 func (c *RequestConfigBase) SetBody(body io.Reader) {
-	c.body = body
+	if buf, ok := body.(*bytes.Buffer); ok {
+		c.body = buf
+	} else {
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(body)
+		c.body = buf
+	}
 }
 
 // RetryConfig returns the retry configuration for the request.


### PR DESCRIPTION
As discussed on #11 

1) For each unique retry attempt, reuse the body from first attempt
2) Removed a redundant return on request_builder_retry_test