### PR TITLE
fix: set headers to override repeated headers

### DIFF
--- a/request.go
+++ b/request.go
@@ -75,14 +75,14 @@ func (b *RequestBuilder) createHTTPRequest() (*http.Request, error) {
 	// Add Client Headers
 	for key, values := range *b.request.client.Header().Unwrap() {
 		for _, value := range values {
-			request.Header.Add(key, value)
+			request.Header.Set(key, value)
 		}
 	}
 
 	// Add Request Headers
 	for key, values := range *b.request.config.Header().Unwrap() {
 		for _, value := range values {
-			request.Header.Add(key, value)
+			request.Header.Set(key, value)
 		}
 	}
 


### PR DESCRIPTION
## Description

<!-- Please provide a clear and concise description of the changes you've made. -->
Changes how set request headers

## Motivation and Context

<!-- Why is this change required? What problem does it solve? 
If it fixes an open issue, please link to the issue here. -->
When add a "base" header on the client builder, then sets the same header, expects to override it, but it goes duplicated.

## How Has This Been Tested?

<!-- Please describe how you've tested your changes (unit tests, integration tests, manual testing, etc.). -->
All current tests was passed

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issues:

<!-- If this PR closes any open issues, please link them here. For example: "Closes #123" --> 
