### PR TITLE
ci: pin Go 1.26.6 for vulnerability checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.25.8', '1.26']
+        go-version: ['1.25.8', '1.26.6']
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -25,31 +25,31 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Run golangci-lint
-        if: matrix.go-version == '1.26'
+        if: matrix.go-version == '1.26.6'
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.10.1
 
       - name: Verify go.mod is tidy
-        if: matrix.go-version == '1.26'
+        if: matrix.go-version == '1.26.6'
         run: go mod tidy && git diff --exit-code go.mod go.sum
 
       - name: Run tests
-        if: matrix.go-version != '1.26'
+        if: matrix.go-version != '1.26.6'
         run: go test -race ./...
 
       - name: Run tests with coverage
-        if: matrix.go-version == '1.26'
+        if: matrix.go-version == '1.26.6'
         run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
       - name: Upload coverage to Codecov
-        if: matrix.go-version == '1.26'
+        if: matrix.go-version == '1.26.6'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run govulncheck
-        if: matrix.go-version == '1.26'
+        if: matrix.go-version == '1.26.6'
         run: go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...
 
   ci-full:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26'
+          go-version: '1.26.6'
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 GOCMD        ?= go
 LINT          = golangci-lint
 VULNCHECK     = govulncheck
-LINT_GOCACHE ?= /tmp/go-cache
-LINT_CACHE   ?= /tmp/golangci-lint-cache
 
 .DEFAULT_GOAL := help
 
@@ -22,11 +20,11 @@ benchmark: check-go ## Run benchmarks
 
 .PHONY: fmt
 fmt: check-go check-lint ## Format code
-	GOCACHE=$(LINT_GOCACHE) GOLANGCI_LINT_CACHE=$(LINT_CACHE) $(LINT) fmt
+	$(LINT) fmt
 
 .PHONY: lint
 lint: check-go check-lint ## Lint code
-	GOCACHE=$(LINT_GOCACHE) GOLANGCI_LINT_CACHE=$(LINT_CACHE) $(LINT) run
+	$(LINT) run
 
 .PHONY: tidy
 tidy: check-go ## Tidy go.mod and go.sum


### PR DESCRIPTION
## What changed

- pinned Go `1.26.6` in the `CI` and `Nightly Quality` gates;
- kept Go `1.25.8` as the minimum version in the test matrix;
- removed fixed global caches under `/tmp` from the `Makefile`, allowing the standard per-user caches to be used.

## Root cause

The workflows declared Go `1.26`, which resolved to `1.26.5`. `govulncheck` reported six reachable vulnerabilities in the standard library, all fixed in Go `1.26.6`, causing both the push CI and nightly workflows to fail.

## Impact

Vulnerability scans now run against the patched Go release. Local lint commands no longer share global caches across users.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/nightly.yml`
- `git diff --check`
- `make fmt lint`
- `go test -race ./...`
- `govulncheck ./...` com Go `1.26.6`
